### PR TITLE
Fix: Fix PLUGIN_DNS_PROVIDER value in docker-compose.yml sample files

### DIFF
--- a/generate/templates/docker-compose.yml.ps1
+++ b/generate/templates/docker-compose.yml.ps1
@@ -31,7 +31,7 @@ $( if ( $PASS_VARIABLES['secret'] ) {
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=$( $VARIANT['tag'] )
+      - PLUGIN_DNS_PROVIDER=$( $VARIANT['_metadata']['package'] )
       - PLUGIN_DNS_CREDENTIALS_FILE=$( if ( $PASS_VARIABLES['secret'] ) { "/run/secrets/certbot_dns_$( $VARIANT['_metadata']['package'] )_credentials.ini" } else { "/etc/letsencrypt/certbot_dns_$( $VARIANT['_metadata']['package'] )_credentials.ini" } )
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-cloudflare/docker-compose.yml
+++ b/variants/v1.10.1-cloudflare/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-cloudflare
+      - PLUGIN_DNS_PROVIDER=cloudflare
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_cloudflare_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-cloudflare/docker-stack.yml
+++ b/variants/v1.10.1-cloudflare/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-cloudflare
+      - PLUGIN_DNS_PROVIDER=cloudflare
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_cloudflare_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-cloudxns/docker-compose.yml
+++ b/variants/v1.10.1-cloudxns/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-cloudxns
+      - PLUGIN_DNS_PROVIDER=cloudxns
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_cloudxns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-cloudxns/docker-stack.yml
+++ b/variants/v1.10.1-cloudxns/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-cloudxns
+      - PLUGIN_DNS_PROVIDER=cloudxns
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_cloudxns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-digitalocean/docker-compose.yml
+++ b/variants/v1.10.1-digitalocean/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-digitalocean
+      - PLUGIN_DNS_PROVIDER=digitalocean
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_digitalocean_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-digitalocean/docker-stack.yml
+++ b/variants/v1.10.1-digitalocean/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-digitalocean
+      - PLUGIN_DNS_PROVIDER=digitalocean
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_digitalocean_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-dnsimple/docker-compose.yml
+++ b/variants/v1.10.1-dnsimple/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-dnsimple
+      - PLUGIN_DNS_PROVIDER=dnsimple
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_dnsimple_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-dnsimple/docker-stack.yml
+++ b/variants/v1.10.1-dnsimple/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-dnsimple
+      - PLUGIN_DNS_PROVIDER=dnsimple
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_dnsimple_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-dnsmadeeasy/docker-compose.yml
+++ b/variants/v1.10.1-dnsmadeeasy/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-dnsmadeeasy
+      - PLUGIN_DNS_PROVIDER=dnsmadeeasy
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_dnsmadeeasy_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-dnsmadeeasy/docker-stack.yml
+++ b/variants/v1.10.1-dnsmadeeasy/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-dnsmadeeasy
+      - PLUGIN_DNS_PROVIDER=dnsmadeeasy
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_dnsmadeeasy_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-google/docker-compose.yml
+++ b/variants/v1.10.1-google/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-google
+      - PLUGIN_DNS_PROVIDER=google
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_google_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-google/docker-stack.yml
+++ b/variants/v1.10.1-google/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-google
+      - PLUGIN_DNS_PROVIDER=google
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_google_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-linode/docker-compose.yml
+++ b/variants/v1.10.1-linode/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-linode
+      - PLUGIN_DNS_PROVIDER=linode
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_linode_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-linode/docker-stack.yml
+++ b/variants/v1.10.1-linode/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-linode
+      - PLUGIN_DNS_PROVIDER=linode
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_linode_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-luadns/docker-compose.yml
+++ b/variants/v1.10.1-luadns/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-luadns
+      - PLUGIN_DNS_PROVIDER=luadns
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_luadns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-luadns/docker-stack.yml
+++ b/variants/v1.10.1-luadns/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-luadns
+      - PLUGIN_DNS_PROVIDER=luadns
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_luadns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-nsone/docker-compose.yml
+++ b/variants/v1.10.1-nsone/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-nsone
+      - PLUGIN_DNS_PROVIDER=nsone
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_nsone_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-nsone/docker-stack.yml
+++ b/variants/v1.10.1-nsone/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-nsone
+      - PLUGIN_DNS_PROVIDER=nsone
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_nsone_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-ovh/docker-compose.yml
+++ b/variants/v1.10.1-ovh/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-ovh
+      - PLUGIN_DNS_PROVIDER=ovh
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_ovh_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-ovh/docker-stack.yml
+++ b/variants/v1.10.1-ovh/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-ovh
+      - PLUGIN_DNS_PROVIDER=ovh
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_ovh_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-rfc2136/docker-compose.yml
+++ b/variants/v1.10.1-rfc2136/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-rfc2136
+      - PLUGIN_DNS_PROVIDER=rfc2136
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_rfc2136_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-rfc2136/docker-stack.yml
+++ b/variants/v1.10.1-rfc2136/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-rfc2136
+      - PLUGIN_DNS_PROVIDER=rfc2136
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_rfc2136_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-route53/docker-compose.yml
+++ b/variants/v1.10.1-route53/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-route53
+      - PLUGIN_DNS_PROVIDER=route53
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_route53_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.10.1-route53/docker-stack.yml
+++ b/variants/v1.10.1-route53/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.10.1-route53
+      - PLUGIN_DNS_PROVIDER=route53
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_route53_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-cloudflare/docker-compose.yml
+++ b/variants/v1.11.0-cloudflare/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-cloudflare
+      - PLUGIN_DNS_PROVIDER=cloudflare
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_cloudflare_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-cloudflare/docker-stack.yml
+++ b/variants/v1.11.0-cloudflare/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-cloudflare
+      - PLUGIN_DNS_PROVIDER=cloudflare
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_cloudflare_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-cloudxns/docker-compose.yml
+++ b/variants/v1.11.0-cloudxns/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-cloudxns
+      - PLUGIN_DNS_PROVIDER=cloudxns
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_cloudxns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-cloudxns/docker-stack.yml
+++ b/variants/v1.11.0-cloudxns/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-cloudxns
+      - PLUGIN_DNS_PROVIDER=cloudxns
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_cloudxns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-digitalocean/docker-compose.yml
+++ b/variants/v1.11.0-digitalocean/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-digitalocean
+      - PLUGIN_DNS_PROVIDER=digitalocean
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_digitalocean_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-digitalocean/docker-stack.yml
+++ b/variants/v1.11.0-digitalocean/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-digitalocean
+      - PLUGIN_DNS_PROVIDER=digitalocean
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_digitalocean_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-dnsimple/docker-compose.yml
+++ b/variants/v1.11.0-dnsimple/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-dnsimple
+      - PLUGIN_DNS_PROVIDER=dnsimple
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_dnsimple_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-dnsimple/docker-stack.yml
+++ b/variants/v1.11.0-dnsimple/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-dnsimple
+      - PLUGIN_DNS_PROVIDER=dnsimple
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_dnsimple_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-dnsmadeeasy/docker-compose.yml
+++ b/variants/v1.11.0-dnsmadeeasy/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-dnsmadeeasy
+      - PLUGIN_DNS_PROVIDER=dnsmadeeasy
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_dnsmadeeasy_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-dnsmadeeasy/docker-stack.yml
+++ b/variants/v1.11.0-dnsmadeeasy/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-dnsmadeeasy
+      - PLUGIN_DNS_PROVIDER=dnsmadeeasy
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_dnsmadeeasy_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-google/docker-compose.yml
+++ b/variants/v1.11.0-google/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-google
+      - PLUGIN_DNS_PROVIDER=google
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_google_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-google/docker-stack.yml
+++ b/variants/v1.11.0-google/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-google
+      - PLUGIN_DNS_PROVIDER=google
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_google_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-linode/docker-compose.yml
+++ b/variants/v1.11.0-linode/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-linode
+      - PLUGIN_DNS_PROVIDER=linode
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_linode_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-linode/docker-stack.yml
+++ b/variants/v1.11.0-linode/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-linode
+      - PLUGIN_DNS_PROVIDER=linode
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_linode_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-luadns/docker-compose.yml
+++ b/variants/v1.11.0-luadns/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-luadns
+      - PLUGIN_DNS_PROVIDER=luadns
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_luadns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-luadns/docker-stack.yml
+++ b/variants/v1.11.0-luadns/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-luadns
+      - PLUGIN_DNS_PROVIDER=luadns
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_luadns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-nsone/docker-compose.yml
+++ b/variants/v1.11.0-nsone/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-nsone
+      - PLUGIN_DNS_PROVIDER=nsone
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_nsone_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-nsone/docker-stack.yml
+++ b/variants/v1.11.0-nsone/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-nsone
+      - PLUGIN_DNS_PROVIDER=nsone
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_nsone_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-ovh/docker-compose.yml
+++ b/variants/v1.11.0-ovh/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-ovh
+      - PLUGIN_DNS_PROVIDER=ovh
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_ovh_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-ovh/docker-stack.yml
+++ b/variants/v1.11.0-ovh/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-ovh
+      - PLUGIN_DNS_PROVIDER=ovh
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_ovh_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-rfc2136/docker-compose.yml
+++ b/variants/v1.11.0-rfc2136/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-rfc2136
+      - PLUGIN_DNS_PROVIDER=rfc2136
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_rfc2136_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-rfc2136/docker-stack.yml
+++ b/variants/v1.11.0-rfc2136/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-rfc2136
+      - PLUGIN_DNS_PROVIDER=rfc2136
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_rfc2136_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-route53/docker-compose.yml
+++ b/variants/v1.11.0-route53/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-route53
+      - PLUGIN_DNS_PROVIDER=route53
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_route53_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.11.0-route53/docker-stack.yml
+++ b/variants/v1.11.0-route53/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.11.0-route53
+      - PLUGIN_DNS_PROVIDER=route53
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_route53_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-cloudflare/docker-compose.yml
+++ b/variants/v1.12.0-cloudflare/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-cloudflare
+      - PLUGIN_DNS_PROVIDER=cloudflare
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_cloudflare_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-cloudflare/docker-stack.yml
+++ b/variants/v1.12.0-cloudflare/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-cloudflare
+      - PLUGIN_DNS_PROVIDER=cloudflare
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_cloudflare_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-cloudxns/docker-compose.yml
+++ b/variants/v1.12.0-cloudxns/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-cloudxns
+      - PLUGIN_DNS_PROVIDER=cloudxns
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_cloudxns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-cloudxns/docker-stack.yml
+++ b/variants/v1.12.0-cloudxns/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-cloudxns
+      - PLUGIN_DNS_PROVIDER=cloudxns
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_cloudxns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-digitalocean/docker-compose.yml
+++ b/variants/v1.12.0-digitalocean/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-digitalocean
+      - PLUGIN_DNS_PROVIDER=digitalocean
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_digitalocean_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-digitalocean/docker-stack.yml
+++ b/variants/v1.12.0-digitalocean/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-digitalocean
+      - PLUGIN_DNS_PROVIDER=digitalocean
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_digitalocean_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-dnsimple/docker-compose.yml
+++ b/variants/v1.12.0-dnsimple/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-dnsimple
+      - PLUGIN_DNS_PROVIDER=dnsimple
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_dnsimple_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-dnsimple/docker-stack.yml
+++ b/variants/v1.12.0-dnsimple/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-dnsimple
+      - PLUGIN_DNS_PROVIDER=dnsimple
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_dnsimple_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-dnsmadeeasy/docker-compose.yml
+++ b/variants/v1.12.0-dnsmadeeasy/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-dnsmadeeasy
+      - PLUGIN_DNS_PROVIDER=dnsmadeeasy
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_dnsmadeeasy_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-dnsmadeeasy/docker-stack.yml
+++ b/variants/v1.12.0-dnsmadeeasy/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-dnsmadeeasy
+      - PLUGIN_DNS_PROVIDER=dnsmadeeasy
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_dnsmadeeasy_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-google/docker-compose.yml
+++ b/variants/v1.12.0-google/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-google
+      - PLUGIN_DNS_PROVIDER=google
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_google_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-google/docker-stack.yml
+++ b/variants/v1.12.0-google/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-google
+      - PLUGIN_DNS_PROVIDER=google
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_google_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-linode/docker-compose.yml
+++ b/variants/v1.12.0-linode/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-linode
+      - PLUGIN_DNS_PROVIDER=linode
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_linode_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-linode/docker-stack.yml
+++ b/variants/v1.12.0-linode/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-linode
+      - PLUGIN_DNS_PROVIDER=linode
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_linode_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-luadns/docker-compose.yml
+++ b/variants/v1.12.0-luadns/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-luadns
+      - PLUGIN_DNS_PROVIDER=luadns
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_luadns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-luadns/docker-stack.yml
+++ b/variants/v1.12.0-luadns/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-luadns
+      - PLUGIN_DNS_PROVIDER=luadns
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_luadns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-nsone/docker-compose.yml
+++ b/variants/v1.12.0-nsone/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-nsone
+      - PLUGIN_DNS_PROVIDER=nsone
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_nsone_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-nsone/docker-stack.yml
+++ b/variants/v1.12.0-nsone/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-nsone
+      - PLUGIN_DNS_PROVIDER=nsone
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_nsone_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-ovh/docker-compose.yml
+++ b/variants/v1.12.0-ovh/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-ovh
+      - PLUGIN_DNS_PROVIDER=ovh
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_ovh_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-ovh/docker-stack.yml
+++ b/variants/v1.12.0-ovh/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-ovh
+      - PLUGIN_DNS_PROVIDER=ovh
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_ovh_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-rfc2136/docker-compose.yml
+++ b/variants/v1.12.0-rfc2136/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-rfc2136
+      - PLUGIN_DNS_PROVIDER=rfc2136
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_rfc2136_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-rfc2136/docker-stack.yml
+++ b/variants/v1.12.0-rfc2136/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-rfc2136
+      - PLUGIN_DNS_PROVIDER=rfc2136
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_rfc2136_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-route53/docker-compose.yml
+++ b/variants/v1.12.0-route53/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-route53
+      - PLUGIN_DNS_PROVIDER=route53
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_route53_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.12.0-route53/docker-stack.yml
+++ b/variants/v1.12.0-route53/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.12.0-route53
+      - PLUGIN_DNS_PROVIDER=route53
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_route53_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-cloudflare/docker-compose.yml
+++ b/variants/v1.9.0-cloudflare/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-cloudflare
+      - PLUGIN_DNS_PROVIDER=cloudflare
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_cloudflare_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-cloudflare/docker-stack.yml
+++ b/variants/v1.9.0-cloudflare/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-cloudflare
+      - PLUGIN_DNS_PROVIDER=cloudflare
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_cloudflare_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-cloudxns/docker-compose.yml
+++ b/variants/v1.9.0-cloudxns/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-cloudxns
+      - PLUGIN_DNS_PROVIDER=cloudxns
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_cloudxns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-cloudxns/docker-stack.yml
+++ b/variants/v1.9.0-cloudxns/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-cloudxns
+      - PLUGIN_DNS_PROVIDER=cloudxns
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_cloudxns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-digitalocean/docker-compose.yml
+++ b/variants/v1.9.0-digitalocean/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-digitalocean
+      - PLUGIN_DNS_PROVIDER=digitalocean
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_digitalocean_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-digitalocean/docker-stack.yml
+++ b/variants/v1.9.0-digitalocean/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-digitalocean
+      - PLUGIN_DNS_PROVIDER=digitalocean
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_digitalocean_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-dnsimple/docker-compose.yml
+++ b/variants/v1.9.0-dnsimple/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-dnsimple
+      - PLUGIN_DNS_PROVIDER=dnsimple
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_dnsimple_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-dnsimple/docker-stack.yml
+++ b/variants/v1.9.0-dnsimple/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-dnsimple
+      - PLUGIN_DNS_PROVIDER=dnsimple
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_dnsimple_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-dnsmadeeasy/docker-compose.yml
+++ b/variants/v1.9.0-dnsmadeeasy/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-dnsmadeeasy
+      - PLUGIN_DNS_PROVIDER=dnsmadeeasy
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_dnsmadeeasy_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-dnsmadeeasy/docker-stack.yml
+++ b/variants/v1.9.0-dnsmadeeasy/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-dnsmadeeasy
+      - PLUGIN_DNS_PROVIDER=dnsmadeeasy
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_dnsmadeeasy_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-google/docker-compose.yml
+++ b/variants/v1.9.0-google/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-google
+      - PLUGIN_DNS_PROVIDER=google
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_google_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-google/docker-stack.yml
+++ b/variants/v1.9.0-google/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-google
+      - PLUGIN_DNS_PROVIDER=google
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_google_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-linode/docker-compose.yml
+++ b/variants/v1.9.0-linode/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-linode
+      - PLUGIN_DNS_PROVIDER=linode
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_linode_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-linode/docker-stack.yml
+++ b/variants/v1.9.0-linode/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-linode
+      - PLUGIN_DNS_PROVIDER=linode
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_linode_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-luadns/docker-compose.yml
+++ b/variants/v1.9.0-luadns/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-luadns
+      - PLUGIN_DNS_PROVIDER=luadns
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_luadns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-luadns/docker-stack.yml
+++ b/variants/v1.9.0-luadns/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-luadns
+      - PLUGIN_DNS_PROVIDER=luadns
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_luadns_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-nsone/docker-compose.yml
+++ b/variants/v1.9.0-nsone/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-nsone
+      - PLUGIN_DNS_PROVIDER=nsone
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_nsone_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-nsone/docker-stack.yml
+++ b/variants/v1.9.0-nsone/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-nsone
+      - PLUGIN_DNS_PROVIDER=nsone
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_nsone_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-ovh/docker-compose.yml
+++ b/variants/v1.9.0-ovh/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-ovh
+      - PLUGIN_DNS_PROVIDER=ovh
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_ovh_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-ovh/docker-stack.yml
+++ b/variants/v1.9.0-ovh/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-ovh
+      - PLUGIN_DNS_PROVIDER=ovh
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_ovh_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-rfc2136/docker-compose.yml
+++ b/variants/v1.9.0-rfc2136/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-rfc2136
+      - PLUGIN_DNS_PROVIDER=rfc2136
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_rfc2136_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-rfc2136/docker-stack.yml
+++ b/variants/v1.9.0-rfc2136/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-rfc2136
+      - PLUGIN_DNS_PROVIDER=rfc2136
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_rfc2136_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-route53/docker-compose.yml
+++ b/variants/v1.9.0-route53/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-route53
+      - PLUGIN_DNS_PROVIDER=route53
       - PLUGIN_DNS_CREDENTIALS_FILE=/etc/letsencrypt/certbot_dns_route53_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 

--- a/variants/v1.9.0-route53/docker-stack.yml
+++ b/variants/v1.9.0-route53/docker-stack.yml
@@ -21,7 +21,7 @@ services:
       - DOMAIN_ADMIN_EMAIL_LOCALPART=admin
 
       # Certbot DNS Plugin
-      - PLUGIN_DNS_PROVIDER=v1.9.0-route53
+      - PLUGIN_DNS_PROVIDER=route53
       - PLUGIN_DNS_CREDENTIALS_FILE=/run/secrets/certbot_dns_route53_credentials.ini
       - PLUGIN_DNS_PROPAGATION_SECONDS=10
 


### PR DESCRIPTION
This MR fixes `PLUGIN_DNS_PROVIDER` environment variable value in docker-compose.yml sample files of all variants.